### PR TITLE
Remove conflicting styles from stylesheet

### DIFF
--- a/src/github-activity.css
+++ b/src/github-activity.css
@@ -1,10 +1,3 @@
-html, body {
-  height: 100%;
-  width: 100%;
-  margin: 0;
-  padding: 0;
-}
-
 .gha-feed {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
I'm not sure whether there's a reason why these styles are there, but they are causing issues for me.

IMO, a widget's CSS should only style the widget, not any of the HTML around it. I can't see why they're needed in the first place, so proposing we just do without.

The widget still looks fine without the styles that I'm proposing be removed.