### PR TITLE
Made single-line activity styles consistent

### DIFF
--- a/src/github-activity.css
+++ b/src/github-activity.css
@@ -159,7 +159,6 @@ span.gha-time {
 
 
 .gha-activity.gha-small {
-  margin-top: 5px;
   font-weight: normal;
   font-size: 13px;
 }
@@ -168,20 +167,8 @@ span.gha-time {
   font-weight: normal;
 }
 
-.gha-activity.gha-small .gha-message {
-  float: left;
-  width: auto;
-  margin-right: 5px;
-  margin-top: 5px;
-}
-
 .gha-activity.gha-small span {
   font-size: 16px;
-}
-
-.gha-activity.gha-small .gha-time {
-  float: left;
-  margin-top: 6px;
 }
 
 .gha-activity:last-child {

--- a/src/github-activity.js
+++ b/src/github-activity.js
@@ -323,7 +323,7 @@ var templates = {
              </div>',
   SingleLineActivity: '<div class="gha-activity gha-small">\
                          <div class="gha-activity-icon"><span class="octicon octicon-{{icon}}"></span></div>\
-                         <div class="gha-message">{{{userLink}}} {{{message}}}</div><div class="gha-time">{{{timeString}}}</div>\
+                         <div class="gha-message"><div class="gha-time">{{{timeString}}}</div>{{{userLink}}} {{{message}}}</div>\
                          <div class="gha-clear"></div>\
                        </div>',
   UserHeader: '<div class="gha-header">\


### PR DESCRIPTION
Made 'single-line' activity styles consistent with other activities, especially noticeable when there are width-constraints on the feed as shown below.

### Before
![Before](http://i.imgur.com/qRYTjEa.png)
### After
![After](http://i.imgur.com/Tal0oER.png)