### PR TITLE
Allow user to be set in url on gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,26 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.2/mustache.min.js"></script>
 <script type="text/javascript" src="github-activity-0.1.4.min.js"></script>
 <script>
+  // Get url params
+  var parseQueryString = function() {
+  var str = window.location.search
+  var objURL = {}
+  str.replace(
+      new RegExp( "([^?=&]+)(=([^&]*))?", "g" ),
+      function( $0, $1, $2, $3 ){
+        objURL[ $1 ] = $3;
+      })
+  return objURL
+  }
+  var params = parseQueryString();
+  if (!params["user"]) params["user"] = 'caseyscarborough';
+  
   function updateFeed(username) {
     GitHubActivity.feed({ username: username, selector: '#feed' });
   }
 
   $(document).ready(function() {
-    updateFeed('caseyscarborough');
+    updateFeed(params["user"]);
 
     $('#update').click(function() { updateFeed($("#username").val()); });
     $("#username").keypress(function(e) {


### PR DESCRIPTION
I often found I wanted to look through my history using this but would search every-time.

I wanted to be able to do something like this:

https://kirkins.github.io/github-activity/?user=kirkins

So I figured I'd send a pull request. Though I realize this may just be adding an unneeded feature to something meant to be an mvp.

Best,
Philip