### PR TITLE
Fixed incorrect gravatar url

### DIFF
--- a/src/github-activity.js
+++ b/src/github-activity.js
@@ -56,7 +56,7 @@ var GitHubActivity = (function() {
           }
           if (i < 2) {
             d.shaLink = methods.renderGitHubLink(data.repo.name + '/commit/' + d.sha, d.sha.substring(0, 6), 'gha-sha');
-            d.committerGravatar = Mustache.render('<img class="gha-gravatar-commit" src="https://gravatar.com/avatar/{{hash}}?s=30&d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png" width="16" />', { hash: md5(d.author.email) });
+            d.committerGravatar = Mustache.render('<img class="gha-gravatar-commit" src="https://gravatar.com/avatar/{{hash}}" width="16" />', { hash: md5(d.author.email.trim().toLowerCase()) });
           } else {
             // Delete the rest of the commits after the first 2, and then break out of the each loop.
             p.commits.splice(2, p.size);


### PR DESCRIPTION
There was an issue before always showing no icons, which it shouldnt even if an email isnt registered with gravatar, will show the default icon. Turns out the old link was invalid, and the code needed to be trimmed(precaution) and lowercased as according to:

https://en.gravatar.com/site/implement/hash/